### PR TITLE
Implement multiple connection support

### DIFF
--- a/common/networkmessage/networkmessage.cpp
+++ b/common/networkmessage/networkmessage.cpp
@@ -56,6 +56,50 @@ std::optional<NetworkMessage> NetworkMessage::TryReceive(Socket& socket) {
 	return NetworkMessage(tag, value);
 }
 
+std::optional<std::tuple<NetworkMessage, size_t>> NetworkMessage::TryFromBuffer(const std::vector<byte>& buffer) {
+	// Tag and length aren't optional, so the message must always be at least the size of them
+	constexpr size_t minSize = sizeof(TagType) + sizeof(Length);
+	if (buffer.size() < minSize) {
+		return std::nullopt;
+	}
+
+	const byte* tagStart = buffer.data();
+	const byte* lengthStart = tagStart + sizeof(TagType);
+	const byte* valueStart = lengthStart + sizeof(Length); // Careful, this is out of bounds if length is 0!
+
+	// ---------------------- LENGTH ----------------------
+
+	// Since we have random access to the bytes, we can check the length field first to
+	// short circuit if the buffer is too small.
+	Length length;
+	std::memcpy(&length, lengthStart, sizeof(Length));
+	length = ntohll(length);
+
+	if (buffer.size() < (minSize + length)) {
+		return std::nullopt;
+	}
+
+	// ---------------------- TAG -------------------------
+
+	TagType rawTag;
+	std::memcpy(&rawTag, tagStart, sizeof(TagType));
+
+	if (!NetworkMessage::IsValidTag(rawTag)) { return std::nullopt; }
+	Tag tag = static_cast<Tag>(rawTag);
+
+	// ---------------------- VALUE -----------------------
+
+	if (length == 0) {
+		return std::make_tuple(NetworkMessage(tag), minSize);
+	}
+
+	// there is data to be read from the socket to populate the buffer
+	Value value(length);
+	std::memcpy(value.data(), valueStart, length);
+
+	return std::make_tuple(NetworkMessage(tag, value), minSize + length);
+}
+
 bool NetworkMessage::Send(Socket& socket) {
 	TagType rawTag = static_cast<TagType>(this->tag);
 	if (!NetworkMessage::IsValidTag(rawTag)) { return false; } // just in case :)

--- a/common/networkmessage/networkmessage.h
+++ b/common/networkmessage/networkmessage.h
@@ -30,8 +30,8 @@ public:
 	enum class Tag : uint8_t { TagValues(CreateEnum) };
 
 	// HERE BE DRAGONS!
-	// If you change these to a type of different width, you NEED to change TryReceive and Send to use
-	// appropriate byte order conversions!
+	// If you change these to a type of different width, you NEED to change TryReceive, TryFromBuffer,
+	// and Send to use appropriate byte order conversions!
 	typedef std::underlying_type_t<NetworkMessage::Tag> TagType;
 	typedef size_t Length;
 	typedef std::vector<byte> Value;
@@ -43,11 +43,25 @@ public:
 
 	NetworkMessage(Tag, Value = Value(0));
 
-	// Tries to receive a message from the specified socket.
-	// Returns std::nullopt if an error occurs, or the message is
-	// malformed, otherwise the received message.
+	/// <summary>
+	/// Tries to receive a message from the specified socket.
+	/// Returns std::nullopt if an error occurs, or the message is </summary>
+	/// malformed, otherwise the received message. <param name="socket"></param>
 	static std::optional<NetworkMessage> TryReceive(Socket& socket);
 
-	// Sends the message on the specified socket.
+	/// <summary>
+	/// Tries to read a message from an existing byte buffer.
+	/// Returns std::nullopt if a message cannot be constructed, otherwise
+	/// returns a tuple containing the NetworkMessage, and the number of bytes
+	/// consumed in the process.
+	/// </summary>
+	/// <param name="buffer">The buffer to try to create a message from</param>
+	/// <returns>std::nullopt if the buffer does not contain a message, otherwise
+	/// a tuple containing the message and the number of bytes consumed.</returns>
+	static std::optional<std::tuple<NetworkMessage, size_t>> TryFromBuffer(const std::vector<byte>& buffer);
+
+	/// <summary>
+	/// Sends the message on the specified socket.
+	/// </summary>
 	bool Send(Socket& socket);
 };

--- a/common/socket/socket.cpp
+++ b/common/socket/socket.cpp
@@ -1,6 +1,9 @@
 #include "socket.h"
 #include "../../win32includes.h"
 
+std::optional<std::string> GetAddress(struct sockaddr_in socketInfo);
+int GetPort(struct sockaddr_in socketInfo);
+
 // Constructor for creation from a platform socket
 Socket::Socket(SOCKET s) : underlyingSocket{ new SOCKET(s) }, referenceCount{ new size_t(1) } {}
 
@@ -284,7 +287,6 @@ bool TCPSocket::Connect(std::string_view hostname, int portNumber) {
 }
 
 std::optional<std::string> TCPSocket::GetBoundAddress() {
-	// we're gonna try this...
 	sockaddr_in socketInfo = { 0 };
 	int socketInfoSize = sizeof(socketInfo);
 
@@ -292,6 +294,44 @@ std::optional<std::string> TCPSocket::GetBoundAddress() {
 		return std::nullopt;
 	}
 
+	return GetAddress(socketInfo);
+}
+
+std::optional<int> TCPSocket::GetBoundPort() {
+	struct sockaddr_in socketInfo = { 0 };
+	int socketInfoLength = sizeof(socketInfo);
+
+	if (getsockname(*underlyingSocket, (struct sockaddr*)&socketInfo, &socketInfoLength) != 0) {
+		return std::nullopt;
+	}
+
+	return GetPort(socketInfo);
+}
+
+std::optional<std::string> TCPSocket::GetPeerAddress() {
+	// we're gonna try this...
+	sockaddr_in socketInfo = { 0 };
+	int socketInfoSize = sizeof(socketInfo);
+
+	if (getpeername(*underlyingSocket, reinterpret_cast<sockaddr*>(&socketInfo), &socketInfoSize) == SOCKET_ERROR) {
+		return std::nullopt;
+	}
+
+	return GetAddress(socketInfo);
+}
+
+std::optional<int> TCPSocket::GetPeerPort() {
+	struct sockaddr_in socketInfo = { 0 };
+	int socketInfoLength = sizeof(socketInfo);
+
+	if (getpeername(*underlyingSocket, (struct sockaddr*)&socketInfo, &socketInfoLength) != 0) {
+		return std::nullopt;
+	}
+
+	return GetPort(socketInfo);
+}
+
+std::optional<std::string> GetAddress(struct sockaddr_in socketInfo) {
 	char addressBuffer[INET_ADDRSTRLEN] = { 0 };
 	if (inet_ntop(AF_INET, &(socketInfo.sin_addr), addressBuffer, sizeof(addressBuffer)) == nullptr) {
 		return std::nullopt;
@@ -314,13 +354,6 @@ std::optional<std::string> TCPSocket::GetBoundAddress() {
 	return addressString;
 }
 
-std::optional<int> TCPSocket::GetBoundPort() {
-	struct sockaddr_in socketInfo = { 0 };
-	int socketInfoLength = sizeof(socketInfo);
-
-	if (getsockname(*underlyingSocket, (struct sockaddr*)&socketInfo, &socketInfoLength) != 0) {
-		return std::nullopt;
-	}
-
+int GetPort(struct sockaddr_in socketInfo) {
 	return ntohs(socketInfo.sin_port);
 }

--- a/common/socket/socket.cpp
+++ b/common/socket/socket.cpp
@@ -166,6 +166,10 @@ Socket::IOResult Socket::ReadAllBytes(byte* buffer, size_t nBytes) {
 	return IOResult::Success;
 }
 
+const SOCKET Socket::GetUnderlyingSocket() const {
+	return *underlyingSocket;
+}
+
 bool Socket::IsValid() {
 	return *underlyingSocket != INVALID_SOCKET;
 }

--- a/common/socket/socket.h
+++ b/common/socket/socket.h
@@ -76,6 +76,9 @@ public:
 	std::optional<std::string> GetBoundAddress();
 	std::optional<int> GetBoundPort();
 
+	std::optional<std::string> GetPeerAddress();
+	std::optional<int> GetPeerPort();
+
 private:
 	TCPSocket(SOCKET existing);
 };

--- a/common/socket/socket.h
+++ b/common/socket/socket.h
@@ -33,6 +33,13 @@ public:
 	IOResult WriteAllBytes(const byte* buffer, size_t nBytes);
 	IOResult ReadAllBytes(byte* buffer, size_t nBytes);
 
+	/// <summary>
+	/// HACK: this provides direct access to the platform-specific
+	/// socket.
+	/// </summary>
+	/// <returns>The underlying socket</returns>
+	const SOCKET GetUnderlyingSocket() const;
+
 	Socket(const Socket& other); // Copy constructor
 	Socket(Socket&& other) noexcept; // Move constructor
 

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -34,6 +34,41 @@ void Server::SetClientDisconnectedHandler(std::function<void(TCPSocket& client)>
 	disconnectHandler = handler;
 }
 
+void Server::InvokeClientConnectedHandler(TCPSocket& client) noexcept {
+	if (!connectHandler) {
+		return;
+	}
+
+	try {
+		(*connectHandler)(client);
+	}
+	catch (...) { /* threw exception, not good! */ }
+}
+
+std::optional<bool> Server::InvokeMessageReceivedHandler(TCPSocket& client, const NetworkMessage message) noexcept {
+	if (!messageHandler) {
+		return std::nullopt;
+	}
+
+	try {
+		return (*messageHandler)(client, message);
+	}
+	catch (...) {
+		return std::nullopt;
+	}
+}
+
+void Server::InvokeClientDisconnectedHandler(TCPSocket& client) noexcept {
+	if (!disconnectHandler) {
+		return;
+	}
+
+	try {
+		(*disconnectHandler)(client);
+	}
+	catch (...) { /* threw exception, not good! */ }
+}
+
 Server::~Server() {
 	listenSocket.Close();
 }
@@ -53,14 +88,7 @@ void SingleConnectServer::Start() {
 		}
 
 		currentClient = *acceptResult;
-		if (connectHandler) {
-			try {
-				(*connectHandler)(currentClient);
-			}
-			catch (...) {
-				// threw exception, not good!
-			}
-		}
+		InvokeClientConnectedHandler(currentClient);
 
 		while (!IsStopRequested()) {
 			std::optional<NetworkMessage> messageOpt = NetworkMessage::TryReceive(currentClient);
@@ -69,32 +97,10 @@ void SingleConnectServer::Start() {
 			}
 
 			const NetworkMessage message = std::move(*messageOpt);
-
-			// Invoke message handler if set
-			if (messageHandler) {
-				try {
-					bool handlerResult = (*messageHandler)(currentClient, message);
-
-					// handler can return false if they want to end the conversation
-					if (!handlerResult) {
-						break;
-					}
-				}
-				catch (...) {
-					// the callback threw an exception, this is not a good thing!
-					break;
-				}
-			}
+			InvokeMessageReceivedHandler(currentClient, message);
 		}
 
-		if (disconnectHandler) {
-			try {
-				(*disconnectHandler)(currentClient);
-			}
-			catch (...) {
-				// threw exception, not good!
-			}
-		}
+		InvokeClientDisconnectedHandler(currentClient);
 
 		currentClient.Close();
 		currentClient = TCPSocket::InvalidSocket();
@@ -114,5 +120,121 @@ void SingleConnectServer::Stop(bool now) {
 bool SingleConnectServer::IsStopRequested() {
 	// if the socket is invalid, the server has been stopped
 	return !listenSocket.IsValid();
+}
+#pragma endregion
+
+#pragma region MultiConnectServer
+MultiConnectServer::MultiConnectServer()
+	: Server(), currentClients{}, clientReadBuffers{}
+{}
+
+// TODO: servers shouldn't allow event handlers to interact with a client socket
+// directly, especially in the MultiConnectServer's case. Its fine for now
+// because IK is feeling overconfident, but its not a great architecture.
+// Better would be to provide event handlers a mechanism to enqueue messages
+// to send, then use a writeSet to write when actually able
+void MultiConnectServer::Start() {
+	while (!IsStopRequested()) {
+
+		// readSet is a set of sockets that we wish to wait for
+		// readability on (ie. incoming connection or data ready to read).
+		fd_set readSet = {};
+		FD_ZERO(&readSet);
+		FD_SET(listenSocket.GetUnderlyingSocket(), &readSet);
+
+		for (auto& clientSocket : currentClients) {
+			FD_SET(clientSocket.GetUnderlyingSocket(), &readSet);
+		}
+
+		// this will block until at least one socket in readSet is readable
+		int selectResult = select(0, &readSet, nullptr, nullptr, nullptr);
+		if (selectResult == SOCKET_ERROR) {
+			continue; // we should really handle this better...
+		}
+
+		// is there an incoming connection?
+		if (FD_ISSET(listenSocket.GetUnderlyingSocket(), &readSet)) {
+			std::optional<TCPSocket> newClient = listenSocket.Accept();
+			if (newClient) {
+				currentClients.push_back(*newClient);
+				InvokeClientConnectedHandler(*newClient);
+			}
+		}
+
+		// are there any pending reads?
+		for (auto clientIterator = currentClients.begin(); clientIterator != currentClients.end();) {
+			SOCKET clientRawSocket = (*clientIterator).GetUnderlyingSocket();
+			if (!FD_ISSET(clientRawSocket, &readSet)) { // socket not ready
+				clientIterator++;
+				continue;
+			}
+
+			unsigned long pendingBytes = 0;
+			if (ioctlsocket(clientRawSocket, FIONREAD, &pendingBytes) == SOCKET_ERROR) {
+				// Drop the connection if we can't know how many bytes are pending
+				clientIterator = EndConnection(clientIterator);
+				continue;
+			}
+
+			// get buffer and its current size
+			std::vector<byte>& buffer = clientReadBuffers[clientRawSocket];
+			size_t originalSize = buffer.size();
+
+			// create room for all buffered + pending bytes
+			buffer.resize(buffer.size() + pendingBytes);
+
+			int readResult = clientIterator->ReadBytes(buffer.data() + originalSize, pendingBytes);
+			if (readResult == SOCKET_ERROR) {
+				// todo: a connection drop handler
+				clientIterator = EndConnection(clientIterator);
+				continue;
+			}
+
+			if (readResult == 0) {
+				// client disconnected
+				InvokeClientDisconnectedHandler(*clientIterator);
+				clientIterator = EndConnection(clientIterator);
+				continue;
+			}
+
+			// resize down to the actual size of data we have (may be different, but probably won't be)
+			buffer.resize(originalSize + readResult);
+
+			std::optional<std::tuple<NetworkMessage, int>> maybeMessage = NetworkMessage::TryFromBuffer(buffer);
+			if (maybeMessage) {
+				auto& [message, consumedBytes] = *maybeMessage;
+				buffer.erase(buffer.begin(), buffer.begin() + consumedBytes);
+
+				InvokeMessageReceivedHandler(*clientIterator, message);
+			}
+
+			clientIterator++;
+		}
+	}
+}
+
+void MultiConnectServer::Stop(bool now) {
+	listenSocket.Close();
+
+	if (now) {
+		// Kill all connected clients during immediate shutdown
+		for (auto iterator = currentClients.begin(); iterator != currentClients.end();) {
+			// DO NOT move the iterator forward!
+			iterator = EndConnection(iterator);
+		}
+	}
+}
+
+bool MultiConnectServer::IsStopRequested() {
+	return !listenSocket.IsValid();
+}
+
+std::vector<TCPSocket>::iterator MultiConnectServer::EndConnection(std::vector<TCPSocket>::iterator& client) {
+	// erase any buffers
+	clientReadBuffers.erase(client->GetUnderlyingSocket());
+
+	// close the connection
+	client->Close();
+	return currentClients.erase(client); // do this last, or `client` will be invalid!
 }
 #pragma endregion

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -121,6 +121,10 @@ bool SingleConnectServer::IsStopRequested() {
 	// if the socket is invalid, the server has been stopped
 	return !listenSocket.IsValid();
 }
+
+int SingleConnectServer::GetConnectionCount() {
+	return currentClient.IsValid() ? 1 : 0;
+}
 #pragma endregion
 
 #pragma region MultiConnectServer
@@ -227,6 +231,10 @@ void MultiConnectServer::Stop(bool now) {
 
 bool MultiConnectServer::IsStopRequested() {
 	return !listenSocket.IsValid();
+}
+
+int MultiConnectServer::GetConnectionCount() {
+	return currentClients.size();
 }
 
 std::vector<TCPSocket>::iterator MultiConnectServer::EndConnection(std::vector<TCPSocket>::iterator& client) {

--- a/server/server.h
+++ b/server/server.h
@@ -7,18 +7,13 @@
 #include "../common/networkmessage/networkmessage.h"
 #include "../win32includes.h"
 
-// todo: use threads to handle each connection so we can have concurrent connections
-// todo: create a mechanism to run some callback when a connection is created/deleted/etc
-
 class Server {
 public:
-	Server();
-
 	bool BindAndListen(std::string& ipAddress, int portNumber);
 
-	void Start();
-	void Stop(bool now = false);
-	bool IsStopRequested();
+	virtual void Start() = 0;
+	virtual void Stop(bool now = false) = 0;
+	virtual bool IsStopRequested() = 0;
 
 	std::optional<std::string> GetHostname();
 	std::optional<int> GetPort();
@@ -29,11 +24,32 @@ public:
 
 	~Server();
 
-private:
+protected:
 	TCPSocket listenSocket;
-	TCPSocket currentClient;
 
 	std::optional<std::function<void(TCPSocket&)>> connectHandler;
 	std::optional<std::function<bool(TCPSocket&, const NetworkMessage)>> messageHandler;
 	std::optional<std::function<void(TCPSocket&)>> disconnectHandler;
+};
+
+/// <summary>
+/// A simple server which accepts only one connection
+/// at a time This isn't very useful, but it is much simpler 
+/// to use compared to MultiConnectServer, so it may be useful
+/// for testing new behaviour.
+/// </summary>
+class SingleConnectServer : public Server {
+public:
+	SingleConnectServer();
+
+	// Inherited via Server
+	void Start() override;
+	void Stop(bool now) override;
+	bool IsStopRequested() override;
+
+private:
+	TCPSocket currentClient;
+};
+
+class MultiConnectServer : public Server {
 };

--- a/server/server.h
+++ b/server/server.h
@@ -22,6 +22,10 @@ public:
 	void SetMessageReceivedHandler(std::function<bool(TCPSocket& client, const NetworkMessage message)> handler);
 	void SetClientDisconnectedHandler(std::function<void(TCPSocket& client)> handler);
 
+	void InvokeClientConnectedHandler(TCPSocket& client) noexcept;
+	std::optional<bool> InvokeMessageReceivedHandler(TCPSocket& client, const NetworkMessage message) noexcept;
+	void InvokeClientDisconnectedHandler(TCPSocket& client) noexcept;
+
 	~Server();
 
 protected:
@@ -34,8 +38,8 @@ protected:
 
 /// <summary>
 /// A simple server which accepts only one connection
-/// at a time This isn't very useful, but it is much simpler 
-/// to use compared to MultiConnectServer, so it may be useful
+/// at a time This isn't very useful, but it is much simpler
+/// compared to MultiConnectServer, so it may be useful
 /// for testing new behaviour.
 /// </summary>
 class SingleConnectServer : public Server {
@@ -52,4 +56,22 @@ private:
 };
 
 class MultiConnectServer : public Server {
+public:
+	MultiConnectServer(); // todo: optional connection limit
+
+	// Inherited via Server
+	void Start() override;
+	void Stop(bool now) override;
+	bool IsStopRequested() override;
+
+private:
+	std::vector<TCPSocket> currentClients;
+	std::unordered_map<SOCKET, std::vector<byte>> clientReadBuffers;
+
+	/// <summary>
+	/// Does all cleanup required to close/drop a connection, including
+	/// releasing any buffers, closing the connection, and removing the
+	/// connection from the current client list
+	/// </summary>
+	std::vector<TCPSocket>::iterator EndConnection(std::vector<TCPSocket>::iterator& client);
 };

--- a/server/server.h
+++ b/server/server.h
@@ -14,6 +14,7 @@ public:
 	virtual void Start() = 0;
 	virtual void Stop(bool now = false) = 0;
 	virtual bool IsStopRequested() = 0;
+	virtual int GetConnectionCount() = 0;
 
 	std::optional<std::string> GetHostname();
 	std::optional<int> GetPort();
@@ -50,6 +51,7 @@ public:
 	void Start() override;
 	void Stop(bool now) override;
 	bool IsStopRequested() override;
+	int GetConnectionCount() override;
 
 private:
 	TCPSocket currentClient;
@@ -63,6 +65,7 @@ public:
 	void Start() override;
 	void Stop(bool now) override;
 	bool IsStopRequested() override;
+	int GetConnectionCount() override;
 
 private:
 	std::vector<TCPSocket> currentClients;

--- a/serverwindow/serverwindow.cpp
+++ b/serverwindow/serverwindow.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <queue>
 #include <optional>
+#include <format>
 
 #include "serverwindow.h"
 #include "serverwindow.thread.cpp"
@@ -13,8 +14,10 @@ ServerWindow::ServerWindow(wxString title, std::string& hostname, int port)
 	this->SetSize(this->FromDIP(wxSize{ 500, 400 }));
 
 	statusBar = new wxStatusBar(this);
-	statusBar->SetStatusText("Nothing happening...");
+	statusBar->SetFieldsCount(2);
 
+	this->SetConnectedClientsCounter(0);
+	this->SetLastLogMessage("All quiet...");
 	this->SetStatusBar(statusBar);
 
 	// GUI Building
@@ -104,4 +107,17 @@ bool ServerWindow::StartServerThread(std::string& hostname, int port) {
 	}
 
 	return true;
+}
+
+void ServerWindow::SetConnectedClientsCounter(int numClients) {
+	const bool plural = numClients != 1;
+	this->statusBar->SetStatusText(std::format(
+		"{} client{} connected",
+		numClients,
+		numClients == 1 ? "" : "s"
+	), 0);
+}
+
+void ServerWindow::SetLastLogMessage(std::string lastMessage) {
+	this->statusBar->SetStatusText(lastMessage, 1);
 }

--- a/serverwindow/serverwindow.cpp
+++ b/serverwindow/serverwindow.cpp
@@ -35,7 +35,7 @@ ServerWindow::ServerWindow(wxString title, std::string& hostname, int port)
 
 	sidebar = new wxScrolledWindow(splitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxVSCROLL);
 	sidebar->SetScrollRate(5, 5);
-	sidebar->SetBackgroundColour(wxColour(255, 255, 255));
+	sidebar->SetBackgroundColour(wxColour(238, 238, 238));
 
 	wxBoxSizer* sidebarItemsSizer = new wxBoxSizer(wxVERTICAL);
 
@@ -92,7 +92,7 @@ bool ServerWindow::StartServerThread(std::string& hostname, int port) {
 	}
 
 	// We have a thread, lets make sure we have a valid Server instance for it to use
-	server = std::make_unique<SingleConnectServer>();
+	server = std::make_unique<MultiConnectServer>();
 
 	if (!server->BindAndListen(hostname, port)) {
 		return false; // can't bind and listen, maybe already taken?

--- a/serverwindow/serverwindow.cpp
+++ b/serverwindow/serverwindow.cpp
@@ -92,7 +92,7 @@ bool ServerWindow::StartServerThread(std::string& hostname, int port) {
 	}
 
 	// We have a thread, lets make sure we have a valid Server instance for it to use
-	server = std::make_unique<Server>();
+	server = std::make_unique<SingleConnectServer>();
 
 	if (!server->BindAndListen(hostname, port)) {
 		return false; // can't bind and listen, maybe already taken?

--- a/serverwindow/serverwindow.events.cpp
+++ b/serverwindow/serverwindow.events.cpp
@@ -34,7 +34,11 @@ void ServerWindow::OnDetails(wxCommandEvent& event) {
 void ServerWindow::OnServerPushLog(wxThreadEvent& event) {
 	// eheh, I love this type system... not... WHY CAN I NOT FORCE A TYPE FOR THE PAYLOAD OF THE EVENT WTF
 	wxString message = event.GetPayload<wxString>();
-	statusBar->SetStatusText(message);
+	this->SetLastLogMessage(message.ToStdString());
+
+	if (this->server) {
+		this->SetConnectedClientsCounter(this->server->GetConnectionCount());
+	}
 }
 
 void ServerWindow::OnClientStartStream(wxThreadEvent& event) {

--- a/serverwindow/serverwindow.h
+++ b/serverwindow/serverwindow.h
@@ -21,6 +21,7 @@ public:
 	};
 
 	ServerWindow(wxString title, std::string& hostname, int port);
+
 protected:
 	// Server data
 	std::unique_ptr<Server> server;
@@ -39,6 +40,9 @@ protected:
 	void OnClientStartStream(wxThreadEvent& event);
 	void OnClientStreamFrameReceived(wxThreadEvent& event);
 	void OnClientEndStream(wxThreadEvent& event);
+
+	void SetConnectedClientsCounter(int numClients);
+	void SetLastLogMessage(std::string lastMessage);
 
 	// Server Thread elements (defined in serverwindow.thread.cpp)
 	bool StartServerThread(std::string& hostname, int port);

--- a/serverwindow/serverwindow.h
+++ b/serverwindow/serverwindow.h
@@ -22,12 +22,15 @@ public:
 
 	ServerWindow(wxString title, std::string& hostname, int port);
 protected:
-	std::unique_ptr<Server> server;
-	VideoStreamWindow* streamWindow;
+	// Server data
+	std::unique_ptr<SingleConnectServer> server;
 
 	// Window elements
-	wxScrolledWindow* logScroller;
-	wxBoxSizer* logContainer;
+	wxSplitterWindow* splitter;
+	wxScrolledWindow* sidebar;
+	wxPanel* mainContentPanel;
+	VideoFrameBitmap* streamView;
+	wxStatusBar* statusBar;
 
 	// Window events (defined in serverwindow.events.cpp)
 	void OnClose(wxCloseEvent& event);
@@ -49,11 +52,4 @@ protected:
 	bool StartVideoStreamMessageHandler(TCPSocket& client, NetworkMessage& message);
 	bool StreamFrameMessageHandler(TCPSocket& client, NetworkMessage& message);
 	bool EndVideoStreamMessageHandler(TCPSocket& client, NetworkMessage& message);
-
-protected:
-	wxSplitterWindow* splitter;
-	wxScrolledWindow* sidebar;
-	wxPanel* mainContentPanel;
-	VideoFrameBitmap* streamView;
-	wxStatusBar* statusBar;
 };

--- a/serverwindow/serverwindow.h
+++ b/serverwindow/serverwindow.h
@@ -23,7 +23,7 @@ public:
 	ServerWindow(wxString title, std::string& hostname, int port);
 protected:
 	// Server data
-	std::unique_ptr<SingleConnectServer> server;
+	std::unique_ptr<Server> server;
 
 	// Window elements
 	wxSplitterWindow* splitter;

--- a/serverwindow/serverwindow.thread.cpp
+++ b/serverwindow/serverwindow.thread.cpp
@@ -41,8 +41,8 @@ void* ServerWindow::Entry() {
 }
 
 void ServerWindow::OnClientConnect(TCPSocket& socket) {
-	std::optional<std::string> hostResult = socket.GetBoundAddress();
-	std::optional<int> portResult = socket.GetBoundPort();
+	std::optional<std::string> hostResult = socket.GetPeerAddress();
+	std::optional<int> portResult = socket.GetPeerPort();
 
 	std::string hostname = hostResult.value_or("<unknown host>");
 	std::string port = portResult.has_value() ? std::to_string(*portResult) : "<unknown port>";
@@ -68,8 +68,8 @@ bool ServerWindow::OnServerMessageReceived(TCPSocket& clientSocket, NetworkMessa
 }
 
 void ServerWindow::OnClientDisconnect(TCPSocket& socket) {
-	std::optional<std::string> hostResult = socket.GetBoundAddress();
-	std::optional<int> portResult = socket.GetBoundPort();
+	std::optional<std::string> hostResult = socket.GetPeerAddress();
+	std::optional<int> portResult = socket.GetPeerPort();
 
 	std::string hostname = hostResult.value_or("<unknown host>");
 	std::string port = portResult.has_value() ? std::to_string(*portResult) : "<unknown port>";


### PR DESCRIPTION
The old server code has been moved into `SingleConnectServer` to preserve it for the time being, in case a revert is required. The new server code is in `MultiConnectServer`. Both implementations inherit from `Server` to make swapping between the two a one-line change (specifically, changing the generic argument to `std::make_unique` in `StartServer()` in `serverwindow.cpp`)